### PR TITLE
Reexported `texture::ImageSize`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "piston-gfx_texture"
-version = "0.0.3"
+version = "0.0.4"
 authors = [
     "bvssvni <bvssvni@gmail.com>",
     "Coeuvre <coeuvre@gmail.com>",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ extern crate gfx;
 extern crate "texture" as texture_lib;
 extern crate image;
 
+pub use texture_lib::ImageSize;
 pub use texture::Texture;
 
 mod texture;


### PR DESCRIPTION
Closes https://github.com/PistonDevelopers/gfx_texture/issues/36