### PR TITLE
Improved compilation time of `image` dependency.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ path = "src/lib.rs"
 
 [dependencies.image]
 git = "https://github.com/PistonDevelopers/image"
+default-features = false
 #version = "~0.2.0"
 
 [dependencies.piston-texture]


### PR DESCRIPTION
Before:
```
cargo build  80.10s user 1.42s system 142% cpu 57.317 total
cargo build --release  92.56s user 1.23s system 137% cpu 1:08.24 total
```
After:
```
cargo build  48.55s user 1.17s system 193% cpu 25.702 total
cargo build --release  54.73s user 1.03s system 185% cpu 29.981 total
```

Closes #40 