### PR TITLE
Fixed CombinedError

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@ use image::{
     RgbaImage,
 };
 use gfx::traits::*;
-use gfx::core::factory::CombinedError;
+use gfx::CombinedError;
 use gfx::format::{Srgba8, R8_G8_B8_A8};
 
 /// Flip settings.


### PR DESCRIPTION
`core` is no longer exposed, was never really meant to be used from the outside.