### PR TITLE
Restore `#[derive(Clone, Debug, PartialEq)]` to `Texture`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,6 +31,7 @@ pub enum Flip {
 }
 
 /// Represents a texture.
+#[derive(Clone, Copy, PartialEq, Eq)]
 pub struct Texture<R> where R: gfx::Resources {
     /// Pixel storage for texture.
     pub surface: gfx::handle::Texture<R, R8_G8_B8_A8>,


### PR DESCRIPTION
Addresses [Add `#[derive(Clone, Debug, PartialEq)]` to `Texture` #76](https://github.com/PistonDevelopers/gfx_texture/issues/76)