### PR TITLE
Derive `Hash` and `Debug` for `Flip`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@ use gfx::CombinedError;
 use gfx::format::{Srgba8, R8_G8_B8_A8};
 
 /// Flip settings.
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
 pub enum Flip {
     /// Does not flip.
     None,


### PR DESCRIPTION
In my hacking, it became inconvenient that I couldn't derive `Hash` on structs
that contained a `Flip` - specifically, I wanted to store resources in a
`HashMap<Box<dyn Hash + Eq + ResourceDescriptor>>`, but my `impl
ResourceDescriptor for (Path, Flip)` failed because `Flip` is not `Hash`. This
commit adds four (4) tokens, deriving `Hash` and `Debug` (because why not,
right?) on `Flip`, in addition to `Clone, Copy, PartialEq, Eq`, which were
already derived.