### PR TITLE
Change Texture::from_path to return the Error type

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "piston-gfx_texture"
-version = "0.42.0"
+version = "0.43.0"
 authors = [
     "bvssvni <bvssvni@gmail.com>",
     "Coeuvre <coeuvre@gmail.com>",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,7 +108,7 @@ impl<R: gfx::Resources> Texture<R> {
         path: P,
         flip: Flip,
         settings: &TextureSettings,
-    ) -> Result<Self, String>
+    ) -> Result<Self, Error>
         where F: gfx::Factory<R>,
               C: gfx::CommandBuffer<R>,
               P: AsRef<Path>
@@ -130,8 +130,7 @@ impl<R: gfx::Resources> Texture<R> {
             Flip::None => img,
         };
 
-        Texture::from_image(context, &img, settings).map_err(
-            |e| format!("{:?}", e))
+        Texture::from_image(context, &img, settings)
     }
 
     /// Creates a texture from image.


### PR DESCRIPTION
Currently, Texture::from_path returns a formatted String of the error.

This just returns that error directly, to make handling and differentiation easier downstream especially for custom error types using libraries like `snafu` and `thiserror` over just a String.